### PR TITLE
track previous axis

### DIFF
--- a/three_by_three/src/cube_ops/cube_move.rs
+++ b/three_by_three/src/cube_ops/cube_move.rs
@@ -1,4 +1,4 @@
-use crate::permutation_math::permutation::Permutation;
+use crate::{cube_ops::cube_prev_axis::CubePreviousAxis, permutation_math::permutation::Permutation};
 
 use super::{
     partial_reprs::{
@@ -111,13 +111,22 @@ impl CubeMove {
         (0u8..18u8).map(|x| unsafe { core::mem::transmute(x) })
     }
 
-    pub fn new_axis_iter(prev_move: Self) -> impl Iterator<Item = Self> {
-        let x = prev_move as u8 / 3;
-        let range_1 = 0u8..(x * 3);
-        let range_2 = ((x + 1) * 3)..18u8;
+    pub fn new_axis_iter(prev_axis: CubePreviousAxis) -> impl IntoIterator<Item = Self> {
+        let (range_1, range_2) = match prev_axis {
+            CubePreviousAxis::U => (0..0, 3..18),
+            CubePreviousAxis::D => (0..3, 6..18),
+            CubePreviousAxis::UD => (0..0, 6..18),
+            CubePreviousAxis::F => (0..6, 9..18),
+            CubePreviousAxis::B => (0..9, 12..18),
+            CubePreviousAxis::FB => (0..6, 12..18),
+            CubePreviousAxis::R => (0..12, 15..18),
+            CubePreviousAxis::L => (0..15, 18..18),
+            CubePreviousAxis::RL => (0..12, 18..18),
+        };
+
         range_1
             .chain(range_2)
-            .map(|x| unsafe { core::mem::transmute(x) })
+            .map(|x: u8| unsafe { core::mem::transmute(x) })
     }
 
     pub const fn into_u8(self) -> u8 {

--- a/three_by_three/src/cube_ops/cube_prev_axis.rs
+++ b/three_by_three/src/cube_ops/cube_prev_axis.rs
@@ -1,0 +1,93 @@
+use std::mem::transmute_copy;
+
+use crate::{CubeMove, cube_ops::cube_sym::DominoSymmetry};
+
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[allow(unused)]
+pub enum CubePreviousAxis {
+    U,
+    D,
+    UD,
+    F,
+    B,
+    FB,
+    R,
+    L,
+    RL,
+}
+
+impl CubePreviousAxis {
+    pub const fn from_first_move(mv: CubeMove) -> Self {
+        match mv as u8 / 3 {
+            0 => Self::U,
+            1 => Self::D,
+            2 => Self::F,
+            3 => Self::B,
+            4 => Self::R,
+            5 => Self::L,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn update_with_new_move(self, mv: CubeMove) -> Self {
+        match (mv as u8 / 3, self) {
+            (0, Self::D) | (1, Self::U) | (0, Self::UD) | (1, Self::UD) => Self::UD,
+            (2, Self::B) | (3, Self::F) | (2, Self::FB) | (3, Self::FB) => Self::FB,
+            (4, Self::L) | (5, Self::R) | (4, Self::RL) | (5, Self::RL) => Self::RL,
+            (0, _) => Self::U,
+            (1, _) => Self::D,
+            (2, _) => Self::F,
+            (3, _) => Self::B,
+            (4, _) => Self::R,
+            (5, _) => Self::L,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn domino_conjugate(self, sym: DominoSymmetry) -> Self {
+        const LOOKUP: [CubePreviousAxis; 9 * 16] = const {
+            let mut lookup = [CubePreviousAxis::U; 9 * 16];
+
+            let mut i = 0usize;
+            
+            while i < 9 * 16 {
+                let prev_axis: CubePreviousAxis = unsafe { std::mem::transmute((i >> 4) as u8) };
+                let sym: DominoSymmetry = unsafe { std::mem::transmute((i & 15) as u8) };
+
+                let (mv, double) = match prev_axis {
+                    CubePreviousAxis::U => (CubeMove::U1, false),
+                    CubePreviousAxis::D => (CubeMove::D1, false),
+                    CubePreviousAxis::UD => (CubeMove::U1, true),
+                    CubePreviousAxis::F => (CubeMove::F1, false),
+                    CubePreviousAxis::B => (CubeMove::B1, false),
+                    CubePreviousAxis::FB => (CubeMove::F1, true),
+                    CubePreviousAxis::R => (CubeMove::R1, false),
+                    CubePreviousAxis::L => (CubeMove::L1, false),
+                    CubePreviousAxis::RL => (CubeMove::R1, true),
+                };
+
+                let mv = mv.domino_conjugate(sym);
+
+                let mut val = CubePreviousAxis::from_first_move(mv);
+
+                if double {
+                    val = match val as u8 / 3 {
+                        0 => CubePreviousAxis::UD,
+                        1 => CubePreviousAxis::FB,
+                        2 => CubePreviousAxis::RL,
+                        _ => unreachable!()
+                    };
+                }
+                
+                lookup[i as usize] = val;
+
+                i += 1;
+            }
+
+            lookup
+        };
+
+        LOOKUP[((self as u8 as usize) << 4) + (sym.0 as usize)]
+    }
+}

--- a/three_by_three/src/cube_ops/mod.rs
+++ b/three_by_three/src/cube_ops/mod.rs
@@ -2,3 +2,4 @@ pub mod cube_move;
 pub mod cube_sym;
 pub mod partial_reprs;
 pub mod repr_cube;
+pub mod cube_prev_axis;


### PR DESCRIPTION
track the previous axes. including if both have been turned. the goal is to prevent move sequences that are trivially locally non-optimal (R L R -> R2 L)

fixes #2 

this is likely more relevant for proving optimality than for finding a sequence so it likely doesn't matter that much for just finding a solution since the pruning table will already be filtering the values this will filter.

not sure yet how this should be handled over the phase change.